### PR TITLE
Update metal effects and GUI

### DIFF
--- a/src/main/java/com/legobmw99/allomancy/modules/powers/client/gui/MetalOverlay.java
+++ b/src/main/java/com/legobmw99/allomancy/modules/powers/client/gui/MetalOverlay.java
@@ -79,22 +79,39 @@ public class MetalOverlay {
         /*
          * The rendering for a the overlay
          */
-
-        for (Metal mt : Metal.values()) {
-            if (cap.hasPower(mt)) {
-                int metalY = 9 - cap.getAmount(mt);
-                int i = mt.getIndex();
-                int offset = (i / 2) * 4; // Adding a gap between pairs
-                // Draw the bars first
-                blit(renderX + 1 + (7 * i) + offset, renderY + 5 + metalY, 7 + (6 * i), 1 + metalY, 3, 10 - metalY);
-                // Draw the gauges second, so that highlights and decorations show over the bar.
-                blit(renderX + (7 * i) + offset, renderY, 0, 0, 5, 20);
-                // Draw the fire if it is burning
-                if (cap.isBurning(mt)) {
-                    blit(renderX + (7 * i) + offset, renderY + 4 + metalY, Frames[currentFrame].x, Frames[currentFrame].y, 5, 3);
+        if (cap.isMistborn()) {
+            for (Metal mt : Metal.values()) {
+                if (cap.hasPower(mt)) {
+                    int metalY = 9 - cap.getAmount(mt);
+                    int i = mt.getIndex();
+                    int offset = (i / 2) * 4; // Adding a gap between pairs
+                    // Draw the bars first
+                    blit(renderX + 1 + (7 * i) + offset, renderY + 5 + metalY, 7 + (6 * i), 1 + metalY, 3, 10 - metalY);
+                    // Draw the gauges second, so that highlights and decorations show over the bar.
+                    blit(renderX + (7 * i) + offset, renderY, 0, 0, 5, 20);
+                    // Draw the fire if it is burning
+                    if (cap.isBurning(mt)) {
+                        blit(renderX + (7 * i) + offset, renderY + 4 + metalY, Frames[currentFrame].x, Frames[currentFrame].y, 5, 3);
+                    }
                 }
-            }
 
+            }
+        } else {
+            for (Metal mt : Metal.values()) {
+                if (cap.hasPower(mt)) {
+                    int metalY = 9 - cap.getAmount(mt);
+                    int i = mt.getIndex();
+                    // Draw the bars first
+                    blit(renderX + 1 + (7), renderY + 5 + metalY, 7 + (6 * i), 1 + metalY, 3, 10 - metalY);
+                    // Draw the gauges second, so that highlights and decorations show over the bar.
+                    blit(renderX + (7), renderY, 0, 0, 5, 20);
+                    // Draw the fire if it is burning
+                    if (cap.isBurning(mt)) {
+                        blit(renderX + (7), renderY + 4 + metalY, Frames[currentFrame].x, Frames[currentFrame].y, 5, 3);
+                    }
+                }
+
+            }
         }
 
         // Update the animation counters

--- a/src/main/java/com/legobmw99/allomancy/modules/powers/util/AllomancyCapability.java
+++ b/src/main/java/com/legobmw99/allomancy/modules/powers/util/AllomancyCapability.java
@@ -37,6 +37,7 @@ public class AllomancyCapability implements ICapabilitySerializable<CompoundNBT>
     private boolean[] burning_metals;
 
     private int damange_stored;
+    private int hunger_stored;
 
     private int death_dimension;
     private BlockPos death_pos;
@@ -64,6 +65,7 @@ public class AllomancyCapability implements ICapabilitySerializable<CompoundNBT>
 
         enhanced_time = 0;
         damange_stored = 0;
+        hunger_stored = 0;
         death_pos = null;
         spawn_pos = null;
 
@@ -204,12 +206,30 @@ public class AllomancyCapability implements ICapabilitySerializable<CompoundNBT>
     }
 
     /**
+     * Get how much hunger has been accumulated
+     *
+     * @return the amount of hunger
+     */
+    public int getHungerStored() {
+        return hunger_stored;
+    }
+
+    /**
      * Set the amount of damage stored
      *
      * @param damageStored the amount of damage
      */
     public void setDamageStored(int damageStored) {
         this.damange_stored = damageStored;
+    }
+
+    /**
+     * Set the amount of hunger stored
+     *
+     * @param hungerStored the amount of damage
+     */
+    public void setHungerStored(int hungerStored) {
+        this.hunger_stored = hungerStored;
     }
 
     public void setDeathLoc(BlockPos pos, DimensionType dim) {


### PR DESCRIPTION
Bendalloy and Cadmium now have more noticable effects. Pewter now gives you full hunger, until you stop burning it, then it removes the negated hunger from your food level; like the pewter health effect already in place. The metal overlay gui now renders individual metals in the corner, instead of wherever it is on the graphic.